### PR TITLE
fix: price input tokens independently of cache

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -10,7 +10,7 @@ const originalFetch = globalThis.fetch
 type TestModel = (typeof AICostModelList)[keyof typeof AICostModelList][number]
 
 function findModel(predicate: (model: TestModel) => boolean): { provider: keyof typeof AICostModelList, model: TestModel } {
-    for (const [provider, models] of Object.entries(AICostModelList) as Array<[keyof typeof AICostModelList, TestModel[]]>) {
+    for (const [provider, models] of Object.entries(AICostModelList) as unknown as Array<[keyof typeof AICostModelList, readonly TestModel[]]>) {
         const model = models.find(predicate)
         if (model) {
             return { provider, model }
@@ -22,14 +22,16 @@ function findModel(predicate: (model: TestModel) => boolean): { provider: keyof 
 
 describe('calculateCost cache pricing', () => {
     beforeAll(() => {
-        globalThis.fetch = (() => Promise.reject(new Error('force local model list'))) as typeof fetch
+        globalThis.fetch = (async () => {
+            throw new Error('force local model list')
+        }) as unknown as typeof fetch
     })
 
     afterAll(() => {
         globalThis.fetch = originalFetch
     })
 
-    it('calculates cache read and cache creation costs when provided', async () => {
+    it('calculates input and cache costs independently when cache tokens are provided', async () => {
         const { provider, model } = findModel(model =>
             model.inputCostUnit === 'token'
             && model.cacheReadInputCost != null
@@ -50,9 +52,7 @@ describe('calculateCost cache pricing', () => {
             cacheCreationInputTokens,
         })
 
-        const adjustedInputAmount = Math.max(inputAmount - cacheReadInputTokens - cacheCreationInputTokens, 0)
-
-        expect(cost.inputCost).toBe(round((model.inputCost ?? 0) * adjustedInputAmount))
+        expect(cost.inputCost).toBe(round((model.inputCost ?? 0) * inputAmount))
         expect(cost.outputCost).toBe(round((model.outputCost ?? 0) * outputAmount))
         expect(cost.cacheReadInputCost).toBe(round((model.cacheReadInputCost ?? 0) * cacheReadInputTokens))
         expect(cost.cacheCreationInputCost).toBe(round((model.cacheCreationInputCost ?? 0) * cacheCreationInputTokens))

--- a/src/index.ts
+++ b/src/index.ts
@@ -157,11 +157,7 @@ export async function calculateCost<P extends LooseString<AICostModelProvider>>(
 
     const pricedCacheReadInputTokens = cacheReadInputCost != null ? cacheReadInputTokens : 0
     const pricedCacheCreationInputTokens = cacheCreationInputCost != null ? cacheCreationInputTokens : 0
-    const adjustedInputAmount = modelInfo.inputCostUnit === 'token'
-        ? Math.max(options.inputAmount - pricedCacheReadInputTokens - pricedCacheCreationInputTokens, 0)
-        : options.inputAmount
-
-    const resolvedInputCost = calculateResolvedCost(inputCost, adjustedInputAmount)
+    const resolvedInputCost = calculateResolvedCost(inputCost, options.inputAmount)
     const resolvedOutputCost = calculateResolvedCost(outputCost, options.outputAmount ?? 0)
     const resolvedCacheReadInputCost = calculateResolvedCost(cacheReadInputCost, pricedCacheReadInputTokens)
     const resolvedCacheCreationInputCost = calculateResolvedCost(cacheCreationInputCost, pricedCacheCreationInputTokens)


### PR DESCRIPTION
## What changed

- price `inputAmount` exactly as supplied
- keep cache-read and cache-creation tokens priced independently
- update cache pricing coverage so subtracting cache tokens from input would fail the regression test
- make the existing test harness compatible with the current TypeScript and fetch types

## Why

`calculateCost` subtracted cache-read and cache-creation tokens from `inputAmount` before pricing input. Callers such as Anthropic expose uncached input tokens separately from cache usage, so the subtraction undercounted input cost and could reduce it to zero whenever cache usage exceeded uncached input.

## Impact

Input, cache-read, and cache-creation costs now reflect their respective caller-provided usage fields without one category reducing another.

## Validation

- `bun test`
- `bunx eslint src/index.ts src/index.test.ts`
- `bunx tsc --noEmit`
- `bun run build`
