### PR TITLE
chore(release): bump aicost to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "aicost",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "description": "An utility for calculating the cost of AI models",
     "repository": "https://github.com/meistrari/aicost",
     "scripts": {


### PR DESCRIPTION
## Summary

- bump the package version from `1.3.0` to `1.4.0`
- trigger the existing publish workflow so the merged Gemini thinking-token and long-context pricing fixes become installable

## Root cause

The publish workflow only runs for pushes to `main` that change `package.json` or the workflow itself. PR #10 changed the implementation and tests without bumping `package.json`, so GitHub filtered out the merge push and never scheduled a publish run.

## Validation

- `bun test` — 12 passed
- `bunx tsc --noEmit`
- `bun run build`
- `bunx eslint package.json`

Repository-wide `bunx eslint .` remains blocked by pre-existing errors in generated model files and README; this one-line release change introduces no new lint errors.